### PR TITLE
Don't Replace Resolutions, Append Them

### DIFF
--- a/Ski-SDUI-MoreRes.plugin.js
+++ b/Ski-SDUI-MoreRes.plugin.js
@@ -22,7 +22,7 @@
 			options += '<option value="' + (64*i) + '">' + (64*i) + '</option>';
 		}
 	}
-    document.getElementById('width').innerHTML = options;
-    document.getElementById('height').innerHTML = options;
+    document.getElementById('width').innerHTML += options;
+    document.getElementById('height').innerHTML += options;
 
 })();


### PR DESCRIPTION
This fixes an oversight where this script replaces all resolutions with its own instead of appending them to the overall list. The old way may interfere with other scripts that add other resolution options.